### PR TITLE
updates to CI following new macos github runner. Added libtiff install when building pyvale from source in github actions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,15 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14, macos-15-intel, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-15-intel, macos-26]
         env-type: [pip]
         include:
           - os: macos-14
             llvm: llvm@15
           - os: macos-15-intel
             llvm: llvm@18
-          - os: macos-latest
-            llvm: llvm@18
+          - os: macos-26
+            llvm: llvm@20
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -46,6 +46,22 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libegl1 libgl1 libxext6 libx11-6
+
+      - name: Install libtiff (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install libtiff
+
+      - name: Install libtiff (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          vcpkg install tiff
+
+      - name: Install libtiff (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libtiff-dev libtiff-tools
 
       - name: Install with pip
         if: matrix.env-type == 'pip'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15-intel, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15-intel, macos-26]
         include:
           - os: macos-14
             llvm: llvm@15
@@ -23,9 +23,9 @@ jobs:
           - os: macos-15-intel
             llvm: llvm@18
             macos_deployment_target: "15.0"
-          - os: macos-latest
-            llvm: llvm@18
-            macos_deployment_target: "15.0"
+          - os: macos-26
+            llvm: llvm@20
+            macos_deployment_target: "26.0"
     steps:
       - uses: actions/checkout@v4
 
@@ -37,14 +37,38 @@ jobs:
           echo "CC=gcc-15" >> $GITHUB_ENV
           echo "CXX=g++-15" >> $GITHUB_ENV
 
+      - name: Install libtiff (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install libtiff
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
           config-file: "{package}/pyproject.toml"
         env:
-          CIBW_SKIP: "pp*"
+          CIBW_SKIP: "*-win32 pp* *musllinux*"
+
+          CIBW_ENVIRONMENT_WINDOWS: >
+            PATH="C:/vcpkg/installed/x64-windows/bin;$PATH"
+
+          CIBW_BEFORE_BUILD_LINUX: |
+            yum install -y libtiff-devel
+
+          CIBW_BEFORE_ALL_WINDOWS: |
+            vcpkg install tiff
+
+          CIBW_BEFORE_BUILD_WINDOWS: |
+            pip install delvewheel
+
+          CIBW_CONFIG_SETTINGS_WINDOWS: >
+            cmake.define.CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
+            delvewheel repair -w "{dest_dir}" "{wheel}"
+
       - uses: actions/upload-artifact@v4
         with:
           name: pyvale-wheels-${{ matrix.os }}-${{ strategy.job-index }}


### PR DESCRIPTION
# Description

github actions changes following release of  macos-26. Added install for libtiff and updated wheel repairs.

Fixes # (issue)


## Type of change

Please mark the relevant options

- [ X] Bug fix (non-breaking change which fixes an issue)



